### PR TITLE
fix: fix error handling in shopping-cart

### DIFF
--- a/src/contexts/cart-context.tsx
+++ b/src/contexts/cart-context.tsx
@@ -114,7 +114,10 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
 			})
 			.catch((error) => {
 				setError((prev) => {
-					return { ...prev, loadCartData: error.errors[0].detail };
+					return {
+						...prev,
+						loadCartData: error.errors?.[0]?.detail || 'Ошибка загрузки корзины покупок',
+					};
 				});
 			})
 			.finally(() => {
@@ -140,7 +143,10 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
 			})
 			.catch((error) => {
 				setError((prev) => {
-					return { ...prev, updateCart: error.errors[0].detail };
+					return {
+						...prev,
+						updateCart: error.errors?.[0]?.detail || 'Ошибка обновления корзины покупок',
+					};
 				});
 			})
 			.finally(() => {
@@ -154,7 +160,11 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
 			.catch((error) => {
 				if (error?.errors) {
 					setError((prev) => {
-						return { ...prev, deleteCart: error.errors[0]?.detail };
+						return {
+							...prev,
+							deleteCart:
+								error.errors[0]?.detail || 'Ошибка удаления товара из корзины покупок',
+						};
 					});
 				}
 			})
@@ -172,9 +182,12 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
 					return { ...prev, clearCart: message };
 				});
 			})
-			.catch(({ errors }) => {
+			.catch((error) => {
 				setError((prev) => {
-					return { ...prev, clearCart: errors };
+					return {
+						...prev,
+						clearCart: error.errors || 'Ошибка очистки корзины покупок',
+					};
 				});
 			});
 	};


### PR DESCRIPTION
Добавил проверки на наличие ожидаемой структуры ответа сервера для кейсов ошибок. В каких-то редких случаях приложение не загружалось при 500-ой ошибке api коризны пользователя.

closes #232